### PR TITLE
Bugfix for preprocessor statement

### DIFF
--- a/src/summary.c
+++ b/src/summary.c
@@ -449,7 +449,7 @@ void print_timing (string, time)
 void summary( returnVal  )
 int * returnVal;
 #endif
-#if defined(LINUX) || (APPLE)
+#if defined(LINUX) || defined(APPLE)
 void summary_ (int *returnVal)
 #endif
 {


### PR DESCRIPTION
This is a tiny bugfix that can be merged anytime. Correct a preprocessor statement by adding the missing `defined()` around `APPLE` in one place. The macro `APPLE` is defined in `CMakeLists.txt`.